### PR TITLE
Replacing faulty ffmpeg buildpack and updating youtube-dl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Now type the following:
 * ``heroku git:remote -a heroku_application_name`` Obviously replace heroku_application_name with the exact name you've given your heroku app when creating it  
 * ``heroku buildpacks:set heroku/python``  
 * ``heroku buildpacks:add https://github.com/Crazycatz00/heroku-buildpack-libopus.git``  
-* ``heroku buildpacks:add https://github.com/jonathanong/heroku-buildpack-ffmpeg-latest.git``  
+* ``heroku buildpacks:add https://github.com/kitcast/buildpack-ffmpeg.git``  
 * ``heroku buildpacks:add https://github.com/guilherme-otran/heroku-buildpack-ffprobe.git``  
 
 Before continuing, don't close the command prompt and make sure the project's root folder contains the following 3 files with the same contents  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py[voice]
 pip
-youtube_dl==2018.11.07
+youtube_dl==2019.01.17
 colorlog
 cffi --only-binary all; 
 aiohttp ~= 2.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/Rapptz/discord.py@rewrite#egg=discord.py[voice]
 pip
-youtube_dl==2019.01.17
+youtube_dl==2019.02.08
 colorlog
 cffi --only-binary all; 
 aiohttp ~= 2.3.10


### PR DESCRIPTION
The ffmpeg buildpack didnt work anymore, resulting in the musicbot not working. Musicbots that already downloaded the ffmpeg-buildpack before the ffmpeg-bulidpack was faulty are not affected.
I replaced the faulty ffmpeg-bp with an working one.
I also updated the youtube-dl version 😄 . The old youtube dl version does work too, but it doesnt support soundclound playlists unlike the newest version.
Thanks for sharing this amazing repo with us, have a good day 👍 